### PR TITLE
chore: Improve error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/USA-RedDragon/sentinel_tunnel
 
 go 1.21.5
+
+require golang.org/x/sync v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+golang.org/x/sync v0.5.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os"
 
 	"github.com/USA-RedDragon/sentinel_tunnel/internal/sentinel"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -52,30 +54,27 @@ type SentinelTunnellingClient struct {
 
 type GetDBAddressByNameFunction func(dbName string) (string, error)
 
-func NewSentinelTunnellingClient(configPath string) *SentinelTunnellingClient {
+func NewSentinelTunnellingClient(configPath string) (*SentinelTunnellingClient, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
-		fatalLog.Printf("an error has occur during configuration read: %v\n", err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("an error has occur during configuration read: %w", err)
 	}
 
 	tunnellingClient := SentinelTunnellingClient{}
 	err = json.Unmarshal(data, &(tunnellingClient.configuration))
 	if err != nil {
-		fatalLog.Printf("an error has occur during configuration unmarshal: %v\n", err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("an error has occur during configuration unmarshal: %w", err)
 	}
 
 	tunnellingClient.sentinelConnection, err =
 		sentinel.NewConnection(tunnellingClient.configuration.SentinelsAddressesList)
 	if err != nil {
-		fatalLog.Printf("an error has occur during sentinel connection creation: %v\n", err.Error())
-		os.Exit(1)
+		return nil, fmt.Errorf("an error has occur during sentinel connection creation: %w", err)
 	}
 
 	infoLog.Println("done initializing tunnelling")
 
-	return &tunnellingClient
+	return &tunnellingClient, nil
 }
 
 func createTunnelling(conn1 net.Conn, conn2 net.Conn) error {
@@ -105,31 +104,43 @@ func handleConnection(c net.Conn, dbName string,
 	}()
 }
 
-func handleSingleDbConnections(listeningPort string, dbName string,
-	getDBAddressByName GetDBAddressByNameFunction) {
+func handleSingleDbConnections(ctx context.Context, listeningPort string, dbName string,
+	getDBAddressByName GetDBAddressByNameFunction) error {
 	listener, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", listeningPort))
 	if err != nil {
-		fatalLog.Printf("cannot listen to port %s: %v\n", listeningPort, err.Error())
-		os.Exit(1)
+		return fmt.Errorf("cannot listen to port %s: %w", listeningPort, err)
 	}
+	go func() {
+		<-ctx.Done()
+		_ = listener.Close()
+	}()
 
 	infoLog.Printf("listening on port %s for connections to database: %s\n", listeningPort, dbName)
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			fatalLog.Printf("cannot accept connections on port %s: %v\n", listeningPort, err.Error())
-			os.Exit(1)
+			return fmt.Errorf("cannot accept connections on port %s: %w", listeningPort, err)
 		}
 		go handleConnection(conn, dbName, getDBAddressByName)
 	}
 }
 
-func (stClient *SentinelTunnellingClient) Start() {
+func (stClient *SentinelTunnellingClient) ListenAndServe(ctx context.Context) error {
+	group, ctx := errgroup.WithContext(ctx)
 	for _, dbConf := range stClient.configuration.Databases {
 		dbConf := dbConf
-		go handleSingleDbConnections(dbConf.LocalPort, dbConf.Name,
-			stClient.sentinelConnection.GetAddressByDbName)
+		group.Go(func() error {
+			return handleSingleDbConnections(
+				ctx,
+				dbConf.LocalPort,
+				dbConf.Name,
+				stClient.sentinelConnection.GetAddressByDbName,
+			)
+		})
 	}
+	//nolint:wrapcheck
+	return group.Wait()
 }
 
 func main() {
@@ -139,9 +150,13 @@ func main() {
 		fatalLog.Printf("usage: %s <config_file_path>\n", os.Args[0])
 		return
 	}
-	stClient := NewSentinelTunnellingClient(os.Args[1])
-	stClient.Start()
-	for {
-		select {}
+	stClient, err := NewSentinelTunnellingClient(os.Args[1])
+	if err != nil {
+		fatalLog.Println(err.Error())
+		os.Exit(1)
+	}
+	if err := stClient.ListenAndServe(context.Background()); err != nil {
+		fatalLog.Println(err.Error())
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func main() {
 	if len(os.Args) < expectedArgs {
 		fatalLog.Printf("not enough arguments\n")
 		fatalLog.Printf("usage: %s <config_file_path>\n", os.Args[0])
-		return
+		os.Exit(1)
 	}
 	stClient, err := NewSentinelTunnellingClient(os.Args[1])
 	if err != nil {


### PR DESCRIPTION
Allows errors to bubble up instead of directly calling `os.Exit` in funcs