### PR TITLE
feat: Proxy Redis errors during connect

### DIFF
--- a/internal/sentinel/resp/resp.go
+++ b/internal/sentinel/resp/resp.go
@@ -32,6 +32,16 @@ func (a Array) String() string {
 	return string(token.Array) + strconv.Itoa(len(a)) + token.EOL + result.String()
 }
 
+// SimpleError builds a simple error
+// See https://redis.io/docs/reference/protocol-spec/#simple-errors
+type SimpleError string
+
+func (s SimpleError) String() string {
+	return string(token.SimpleError) + string(s) + token.EOL
+}
+
+// SimpleString builds a simple string
+// See https://redis.io/docs/reference/protocol-spec/#simple-strings
 type SimpleString string
 
 func (s SimpleString) String() string {

--- a/internal/sentinel/resp/token/token.go
+++ b/internal/sentinel/resp/token/token.go
@@ -2,7 +2,7 @@ package token
 
 const (
 	SimpleString = '+'
-	SimpleErr    = '-'
+	SimpleError  = '-'
 	BulkString   = '$'
 	Array        = '*'
 	EOF

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strconv"
 	"time"
@@ -130,7 +131,7 @@ func (c *Connection) retrieveAddressByDbName(password string) {
 	for dbName := range c.getMasterAddressByName {
 		response, isClientClosed, err := c.getMasterAddrByNameFromSentinel(dbName, password)
 		if err != nil {
-			fmt.Println("err: ", err.Error())
+			slog.Error("failed to get master", "error", err.Error())
 			if !isClientClosed {
 				var reply string
 				if len(response) != 0 {
@@ -172,7 +173,7 @@ func (c *Connection) reconnectToSentinel() bool {
 			c.writer = bufio.NewWriter(c.currentConnection)
 			return true
 		}
-		fmt.Println(err.Error())
+		slog.Error("failed to reconnect to Sentinel", "error", err.Error())
 	}
 	return false
 }


### PR DESCRIPTION
This makes Redis errors get proxied to the client.

Before:
```
/tmp # redis-cli
127.0.0.1:6379> keys *
Error: Server closed the connection
```

After:
```
/tmp # redis-cli
127.0.0.1:6379> keys *
(error) ERR Tunnel failed to get db: NOAUTH Authentication required.
```